### PR TITLE
Remove dateutils dependancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ veeam
 sqlite3 (>= 3.7.0)  
 curl (only for vee-mail update check)  
 sendmail (your system should be able to send mails with sendmail command - postfix, bsd-mailx, nullmailer,...)
-dateutils
 
 # Install
 
@@ -27,6 +26,9 @@ You can use the vee-mail script as a post-backup script directly in veeam (Confi
 /opt/vee-mail/vee-mail.sh
 
 # Release notes
+
+## Version 0.5.36
+remove dateutils dependancy
 
 ## Version 0.5.35
 remove bc dependancy

--- a/vee-mail.sh
+++ b/vee-mail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=0.5.35
+VERSION=0.5.36
 HDIR=$(dirname "$0")
 DEBUG=0
 INFOMAIL=1
@@ -67,15 +67,6 @@ if [ "$SENDMAIL" != "/usr/sbin/sendmail" ] && [ "$SENDMAIL" != "/bin/sendmail" ]
   yum install -y sendmail
  else
   apt-get install -y sendmail
- fi
-fi
-
-DATEUTILS_DDIFF=$(which dateutils.ddiff)
-if [ "$DATEUTILS_DDIFF" != "/usr/bin/dateutils.ddiff" ] && [ "$DATEUTILS_DDIFF" != "/bin/dateutils.ddiff" ]; then
- if [ "$YUM" ]; then
-  yum install -y dateutils
- else
-  apt-get install -y dateutils
  fi
 fi
 
@@ -216,7 +207,8 @@ if [ "$TARGETLOAD" -gt "$SOURCELOAD" ] && [ "$TARGETLOAD" -gt "$SOURCEPLOAD" ] &
  BOTTLENECK="Target"
 fi
 
-DURATION=$($DATEUTILS_DDIFF -i %s -f "%H:%M:%S" "$STARTTIME" "$ENDTIME")
+let DUR=ENDTIME-STARTTIME DURATIONSEC=DUR%60 DURATIONMIN=\(DUR-DURATIONSEC\)/60%60 DURATIONHOUR=\(DUR-DURATIONSEC-\(DURATIONMIN*60\)\)/3600
+DURATION=$(printf "%d:%02d:%02d\n" $DURATIONHOUR $DURATIONMIN $DURATIONSEC)
 START=$(date -d "@$STARTTIME" +"%A, %d %B %Y %H:%M:%S")
 END=$(date -d "@$ENDTIME" +"%A, %d.%m.%Y %H:%M:%S")
 STIME=$(date -d "@$STARTTIME" +"%H:%M:%S")


### PR DESCRIPTION
backup duration can be calculated with integer math.
This allows to remove dateutils dependancy.

I reused this nice guide (let or declare chapter):
https://www.shell-tips.com/bash/math-arithmetic-calculation/#using-the-let-or-declare-shell-builtin-commands