### PR TITLE
Fix empty body for outlook.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ You can use the vee-mail script as a post-backup script directly in veeam (Confi
 
 # Release notes
 
+## Version 0.5.38
+fix message blank line ending header following RFC (fix reception by outlook.com)
+
 ## Version 0.5.37
 offer use of curl instead of sendmail (sendmail is still the default)
 

--- a/vee-mail.sh
+++ b/vee-mail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=0.5.37
+VERSION=0.5.38
 HDIR=$(dirname "$0")
 DEBUG=0
 INFOMAIL=1

--- a/vee-mail.sh
+++ b/vee-mail.sh
@@ -247,13 +247,13 @@ TEMPFILE=$(mktemp)
 HN=${HOSTNAME^^}
 
 # build email
-echo "From: $EMAILFROM
+echo -en "From: $EMAILFROM
 To: $EMAILTO
 Subject: =?UTF-8?Q?[$STAT] $HN - $START?=
 MIME-Version: 1.0
 Content-Type: text/html; charset=utf-8
-Content-Transfer-Encoding: 8bit
-
+Content-Transfer-Encoding: 8bit\r
+\r
 " > $TEMPFILE
 
 # debug output


### PR DESCRIPTION
blank line after message header should CRLFCRLF
That fixes empty body of mail when sent to outlook.com