### PR TITLE
Fix password issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ You can use the vee-mail script as a post-backup script directly in veeam (Confi
 
 # Release notes
 
+## Version 0.5.40
+Fix password issue
+
 ## Version 0.5.39
 Bugfix version check
 

--- a/vee-mail.config
+++ b/vee-mail.config
@@ -11,7 +11,7 @@ SKIPVERSIONCHECK=0
 # if you backup to a smb-share fill in your credentials to get infos about free backup space
 SMBUSER=""
 SMBPWD=""
-# infomail: 1=always, 2=warning only, 3=error only
+# infomail: 1=always, 2=warning and error only, 3=error only
 INFOMAIL=1
 # if set to 1 get more debug output on script run
 DEBUG=0

--- a/vee-mail.sh
+++ b/vee-mail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=0.5.39
+VERSION=0.5.40
 HDIR=$(dirname "$0")
 DEBUG=0
 INFOMAIL=1

--- a/vee-mail.sh
+++ b/vee-mail.sh
@@ -269,10 +269,6 @@ if [ $SENDM -eq 1 ]; then
 
   CURLPARAMS=""
 
-  if [ "$CURLUSERNAME" ]; then
-   CURLPARAMS=" $CURLPARAMS --user \"$CURLUSERNAME:$CURLPASSWORD\""
-  fi
-
   if [ $CURLSTARTTLS -eq 1 ]; then
    CURLPARAMS=" $CURLPARAMS --ssl-reqd"
   fi
@@ -281,7 +277,7 @@ if [ $SENDM -eq 1 ]; then
    CURLPARAMS=" $CURLPARAMS --insecure"
   fi
 
-  $CURL -sS --url $CURLSMTPSERVER --mail-from $EMAILFROM --mail-rcpt $EMAILTO --upload-file $TEMPFILE $CURLPARAMS
+  $CURL -sS --url $CURLSMTPSERVER --mail-from $EMAILFROM --mail-rcpt $EMAILTO --upload-file $TEMPFILE ${CURLUSERNAME:+-u $CURLUSERNAME:"$CURLPASSWORD"} $CURLPARAMS
  else
   cat $TEMPFILE | $SENDMAIL -f $EMAILFROM -t
  fi


### PR DESCRIPTION
I've found that my code is sending a single quote in login at first position and in password at last position
I've changed the way this param is handled for curl call and validated it with smtp4dev
this way password can contains whitespace, dollarsign, double quote, etc
(for dollar sign and double quote, they need for sure to be escaped in config file by a backslash)