### PR TITLE
Adjustment of script to accommodate comma separated job names

### DIFF
--- a/vee-mail.config
+++ b/vee-mail.config
@@ -1,5 +1,5 @@
-# name of the veeam backup job as set in veeam!
-JOBNAME="myJobName"
+# Comma-separated list of Veeam job names
+JOBNAME="Backblaze,AnotherBackupJob,DailyAllVMs"
 # the sender email address
 EMAILFROM="mail@my.domain"
 # receiver email address

--- a/vee-mail.sh
+++ b/vee-mail.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 
+# vee-mail.sh
+# Full script example that loops through multiple job names
+# from a comma-separated JOBNAME in vee-mail.config.
+
 VERSION=0.5.49
 HDIR=$(dirname "$0")
+
+##################################################
+# Default or initial values
+##################################################
 DEBUG=0
 INFOMAIL=1
 SENDM=0
@@ -13,17 +21,19 @@ if [[ $EUID -ne 0 ]]; then
   exit 1
 fi
 
-# Source your config
-. $HDIR/$1
+# Source config (the .config file, presumably vee-mail.config)
+. "$HDIR/$1"
 
-# Make sure the script picks up the multiple job names
-IFS=',' read -ra JOBS <<< "$JOBNAME"
+# If config sets SLEEP, use that; else default stays 60
+if [ -z "$SLEEP" ]; then
+  SLEEP=60
+fi
 
 STARTEDFROM=$(ps -p $PPID -hco cmd)
 if [ "$1" == "--bg" ]; then
   if [ "$STARTEDFROM" == "veeamjobman" ]; then
     logger -t vee-mail "waiting for ${SLEEP} seconds"
-    sleep $SLEEP
+    sleep "$SLEEP"
   fi
 fi
 
@@ -31,77 +41,404 @@ VC=$(which veeamconfig)
 if [ -z "$VC" ]; then
   echo "No Veeam Agent for Linux installed!"
   logger -t vee-mail "No Veeam Agent for Linux installed!"
+  exit 1
+fi
+
+VV=$($VC -v 2>/dev/null | cut -c2)
+YUM=$(which yum 2>/dev/null)
+SQLITE=$(which sqlite3 2>/dev/null)
+CURL=$(which curl 2>/dev/null)
+SENDMAIL=$(which sendmail 2>/dev/null)
+
+##################################################
+# Install dependencies if missing
+##################################################
+if [ "$SQLITE" != "/usr/bin/sqlite3" ] && [ "$SQLITE" != "/bin/sqlite3" ]; then
+  if [ "$YUM" ]; then
+    yum install -y sqlite3
+  else
+    apt-get install -y sqlite3
+  fi
+fi
+
+if [ $USECURL -eq 1 ] && [ -z "$CURL" ]; then
+  if [ "$YUM" ]; then
+    yum install -y curl
+  else
+    apt-get install -y curl
+  fi
+fi
+
+if [ $USECURL -ne 1 ] && [ "$SENDMAIL" != "/usr/sbin/sendmail" ] && [ "$SENDMAIL" != "/bin/sendmail" ]; then
+  if [ "$YUM" ]; then
+    yum install -y sendmail
+  else
+    apt-get install -y sendmail
+  fi
+fi
+
+##################################################
+# Optional version check if SKIPVERSIONCHECK=0
+##################################################
+if [ $SKIPVERSIONCHECK -ne 1 ]; then
+  if [ "$CURL" ]; then
+    AKTVERSION=$($CURL -m2 -f -s https://raw.githubusercontent.com/grufocom/vee-mail/master/vee-mail.sh --stderr - | grep "^VERSION=" | awk -F'=' '{print $2}')
+    if [ "$AKTVERSION" ]; then
+      HIGHESTVERSION=$(echo -e "$VERSION\n$AKTVERSION" | sort -rV | head -n1)
+      if [ "$VERSION" != "$HIGHESTVERSION" ]; then
+        logger -t vee-mail "new Vee-Mail version $AKTVERSION available"
+        AKTVERSION="(new Vee-Mail version $AKTVERSION available)"
+      else
+        AKTVERSION=""
+      fi
+    fi
+  else
+    AKTVERSION="(you need curl to use the upgrade check, please install)"
+  fi
+else
+  VERSION="$VERSION (upgrade check disabled)"
+fi
+
+AGENT=$($VC -v)
+
+##################################################
+# Grab multiple job names from config
+##################################################
+IFS=',' read -ra JOBS <<< "$JOBNAME"
+
+##################################################
+# Function: build and send mail for the given job
+##################################################
+function send_job_mail() {
+  local oneJobName="$1"
+
+  ######################################
+  # Step 1: Grab the latest session from DB for the job
+  #
+  # Because older Veeam versions don't have --name, we rely
+  # on the DB to filter by job_name. This avoids "Unknown argument" errors.
+  ######################################
+  local SESSDATA
+  if [ "$VV" -ge 6 ]; then
+    # For v6+ we might use start_time_utc
+    SESSDATA=$(sqlite3 /var/lib/veeam/veeam_db.sqlite \
+      "SELECT start_time_utc, end_time_utc, state, progress_details, job_id, job_name, session_id
+       FROM JobSessions
+       WHERE job_name='$oneJobName'
+       ORDER BY start_time_utc DESC
+       LIMIT 1;")
+  else
+    # For older v3-v5, use start_time
+    SESSDATA=$(sqlite3 /var/lib/veeam/veeam_db.sqlite \
+      "SELECT start_time, end_time, state, progress_details, job_id, job_name, session_id
+       FROM JobSessions
+       WHERE job_name='$oneJobName'
+       ORDER BY start_time DESC
+       LIMIT 1;")
+  fi
+
+  # If there's no session data, bail for this job
+  if [ -z "$SESSDATA" ]; then
+    logger -t vee-mail "No session for job [$oneJobName], skipping..."
+    return
+  fi
+
+  local STARTTIME ENDTIME STATE DETAILS JOBID THISJOBNAME SESSID
+  STARTTIME=$( echo "$SESSDATA" | awk -F'|' '{print $1}' )
+  ENDTIME=$(   echo "$SESSDATA" | awk -F'|' '{print $2}' )
+  STATE=$(     echo "$SESSDATA" | awk -F'|' '{print $3}' )
+  DETAILS=$(   echo "$SESSDATA" | awk -F'|' '{print $4}' )
+  JOBID=$(     echo "$SESSDATA" | awk -F'|' '{print $5}' )
+  THISJOBNAME=$(echo "$SESSDATA"| awk -F'|' '{print $6}' )
+  SESSID=$(    echo "$SESSDATA" | awk -F'|' '{print $7}' )
+
+  # Basic sanity check: if we have no session_id or job_id, skip
+  if [ -z "$SESSID" ] || [ -z "$JOBID" ]; then
+    logger -t vee-mail "No valid session ID or job ID for [$oneJobName]"
+    return
+  fi
+
+  ######################################
+  # Step 2: Get session log (error/warn)
+  ######################################
+  local ERRLOG
+  ERRLOG=$($VC session log --id "$SESSID" 2>/dev/null \
+           | egrep 'error|warn' \
+           | sed ':a;N;$!ba;s/\n/<br>/g' \
+           | sed -e "s/ /\\&nbsp;/g")
+  ERRLOG=$(printf "%q" "$ERRLOG")
+  if [ "$ERRLOG" == "''" ]; then
+    ERRLOG=""
+  fi
+
+  ######################################
+  # Step 3: Parse the DB to find the backup target info (like original script)
+  ######################################
+  local RAWTARGET TARGET FST LOGIN DOMAIN LOCALDEV
+  RAWTARGET=$(sqlite3 /var/lib/veeam/veeam_db.sqlite \
+    "SELECT a1.options
+     FROM BackupRepositories AS a1
+     LEFT JOIN BackupJobs AS a2 ON a1.id = a2.repository_id
+     WHERE a2.id='$JOBID';")
+
+  TARGET=$(echo "$RAWTARGET" \
+    | awk -F'Address="' '{print $2}' \
+    | awk -F'"' '{print $1}' \
+    | sed -e "s/^\\///g")
+
+  FST=$(echo "$RAWTARGET" \
+    | awk -F'FsType="' '{print $2}' \
+    | awk -F'"' '{print $1}')
+
+  LOGIN=$(echo "$RAWTARGET" \
+    | awk -F'Login="' '{print $2}' \
+    | awk -F'"' '{print $1}')
+
+  DOMAIN=$(echo "$RAWTARGET" \
+    | awk -F'Domain="' '{print $2}' \
+    | awk -F'"' '{print $1}')
+
+  # If no "TARGET" from network share, maybe it's local deviceMountPoint
+  if [ -z "$TARGET" ]; then
+    TARGET=$(echo "$RAWTARGET" \
+      | awk -F'DeviceMountPoint="' '{print $2}' \
+      | awk -F'"' '{print $1}')
+    local AWKTARGET
+    AWKTARGET=$(echo "$TARGET" | sed 's@/@\\/@g')
+    FST=$(mount | awk -vORS=" " "\$3 ~ /^${AWKTARGET}\$/ {print \$5}")
+    local FSD
+    FSD=$(mount | awk -vORS=" " "\$3 ~ /^${AWKTARGET}\$/ {print \$1}")
+    local DEVSIZE DEVUSED DEVAVAIL DEVUSEP
+    DEVSIZE=$(df -hP | awk "\$6 ~ /^${AWKTARGET}\$/ {print \$2}" | sed -e "s/,/./g" -e "s/M/ M/g" -e "s/G/ G/g" -e "s/T/ T/g" -e "s/P/ P/g")
+    DEVUSED=$(df -hP | awk "\$6 ~ /^${AWKTARGET}\$/ {print \$3}" | sed -e "s/,/./g" -e "s/M/ M/g" -e "s/G/ G/g" -e "s/T/ T/g" -e "s/P/ P/g")
+    DEVAVAIL=$(df -hP | awk "\$6 ~ /^${AWKTARGET}\$/ {print \$4}" | sed -e "s/,/./g" -e "s/M/ M/g" -e "s/G/ G/g" -e "s/T/ T/g" -e "s/P/ P/g")
+    DEVUSEP=$(df -hP | awk "\$6 ~ /^${AWKTARGET}\$/ {print \$5}" | sed -e "s/,/./g" -e "s/M/ M/g" -e "s/G/ G/g" -e "s/T/ T/g" -e "s/P/ P/g")
+    LOGIN=""
+    DOMAIN=""
+    LOCALDEV=1
+  fi
+
+  # If it's a network share, we can try to mount to gather stats, etc.
+  if [ "$FST" == "cifs" ] || [ "$FST" == "smb" ] && [ "$LOCALDEV" != "1" ]; then
+    local MPOINT AWKMPOINT DEVSIZE DEVUSED DEVAVAIL DEVUSEP
+    if [ -n "$SMBUSER" ] && [ -n "$SMBPWD" ]; then
+      MPOINT=$(mktemp -d)
+      AWKMPOINT=$(echo "$MPOINT" | sed 's@/@\\/@g')
+      mount -t cifs -o username=$SMBUSER,password=$SMBPWD,domain=$DOMAIN "//${TARGET}" "$MPOINT"
+      DEVSIZE=$(df -hP | awk "\$6 ~ /^${AWKMPOINT}\$/ {print \$2}" | sed -e "s/,/./g" -e "s/M/ M/g" -e "s/G/ G/g" -e "s/T/ T/g" -e "s/P/ P/g")
+      DEVUSED=$(df -hP | awk "\$6 ~ /^${AWKMPOINT}\$/ {print \$3}" | sed -e "s/,/./g" -e "s/M/ M/g" -e "s/G/ G/g" -e "s/T/ T/g" -e "s/P/ P/g")
+      DEVAVAIL=$(df -hP | awk "\$6 ~ /^${AWKMPOINT}\$/ {print \$4}" | sed -e "s/,/./g" -e "s/M/ M/g" -e "s/G/ G/g" -e "s/T/ T/g" -e "s/P/ P/g")
+      DEVUSEP=$(df -hP | awk "\$6 ~ /^${AWKMPOINT}\$/ {print \$5}" | sed -e "s/,/./g" -e "s/M/ M/g" -e "s/G/ G/g" -e "s/T/ T/g" -e "s/P/ P/g")
+      umount "$MPOINT"
+      rmdir "$MPOINT"
+    fi
+  fi
+
+  if [ "$FST" == "nfs" ] && [ "$LOCALDEV" != "1" ]; then
+    local MPOINT AWKMPOINT DEVSIZE DEVUSED DEVAVAIL DEVUSEP
+    MPOINT=$(mktemp -d)
+    mount -t nfs "$TARGET" "$MPOINT"
+    AWKMPOINT=$(echo "$MPOINT" | sed 's@/@\\/@g')
+    DEVSIZE=$(df -hP | awk "\$6 ~ /^${AWKMPOINT}\$/ {print \$2}" | sed -e "s/,/./g" -e "s/M/ M/g" -e "s/G/ G/g" -e "s/T/ T/g" -e "s/P/ P/g")
+    DEVUSED=$(df -hP | awk "\$6 ~ /^${AWKMPOINT}\$/ {print \$3}" | sed -e "s/,/./g" -e "s/M/ M/g" -e "s/G/ G/g" -e "s/T/ T/g" -e "s/P/ P/g")
+    DEVAVAIL=$(df -hP | awk "\$6 ~ /^${AWKMPOINT}\$/ {print \$4}" | sed -e "s/,/./g" -e "s/M/ M/g" -e "s/G/ G/g" -e "s/T/ T/g" -e "s/P/ P/g")
+    DEVUSEP=$(df -hP | awk "\$6 ~ /^${AWKMPOINT}\$/ {print \$5}" | sed -e "s/,/./g" -e "s/M/ M/g" -e "s/G/ G/g" -e "s/T/ T/g" -e "s/P/ P/g")
+    umount "$MPOINT"
+    rmdir "$MPOINT"
+  fi
+
+  ######################################
+  # Step 4: parse backup job metrics
+  ######################################
+  local PROCESSED READ TRANSFERRED SPEED SOURCELOAD SOURCEPLOAD NETLOAD TARGETLOAD BOTTLENECK
+  PROCESSED=$(echo "$DETAILS" | awk -F'processed_data_size_bytes="' '{print $2}' | awk -F'"' '{print $1}')
+  PROCESSED=$(awk "BEGIN {printf \"%.1f\n\", $PROCESSED/1024/1024/1024}")" GB"
+
+  READ=$(echo "$DETAILS" | awk -F'read_data_size_bytes="' '{print $2}' | awk -F'"' '{print $1}')
+  READ=$(awk "BEGIN {printf \"%.1f\n\", $READ/1024/1024/1024}")" GB"
+
+  TRANSFERRED=$(echo "$DETAILS" | awk -F'transferred_data_size_bytes="' '{print $2}' | awk -F'"' '{print $1}')
+  if [ -n "$TRANSFERRED" ] && [ "$TRANSFERRED" -gt 1073741824 ] 2>/dev/null; then
+    TRANSFERRED=$(awk "BEGIN {printf \"%.1f\n\", $TRANSFERRED/1024/1024/1024}")" GB"
+  else
+    TRANSFERRED=$(awk "BEGIN {printf \"%.0f\n\", $TRANSFERRED/1024/1024}")" MB"
+  fi
+
+  SPEED=$(echo "$DETAILS" | awk -F'processing_speed="' '{print $2}' | awk -F'"' '{print $1}')
+  SPEED=$(awk "BEGIN {printf \"%.1f\n\", $SPEED/1024/1024}")
+
+  SOURCELOAD=$(echo "$DETAILS" | awk -F'source_read_load="' '{print $2}' | awk -F'"' '{print $1}')
+  SOURCEPLOAD=$(echo "$DETAILS" | awk -F'source_processing_load="' '{print $2}' | awk -F'"' '{print $1}')
+  NETLOAD=$(echo "$DETAILS" | awk -F'network_load="' '{print $2}' | awk -F'"' '{print $1}')
+  TARGETLOAD=$(echo "$DETAILS" | awk -F'target_write_load="' '{print $2}' | awk -F'"' '{print $1}')
+
+  # Bottleneck logic
+  BOTTLENECK=""
+  if [ -n "$SOURCELOAD" ] && [ -n "$SOURCEPLOAD" ] && [ -n "$NETLOAD" ] && [ -n "$TARGETLOAD" ]; then
+    if [ "$SOURCELOAD" -ge "$SOURCEPLOAD" ] && [ "$SOURCELOAD" -ge "$NETLOAD" ] && [ "$SOURCELOAD" -ge "$TARGETLOAD" ]; then
+      BOTTLENECK="Source"
+    fi
+    if [ "$SOURCEPLOAD" -gt "$SOURCELOAD" ] && [ "$SOURCEPLOAD" -gt "$NETLOAD" ] && [ "$SOURCEPLOAD" -gt "$TARGETLOAD" ]; then
+      BOTTLENECK="Source CPU"
+    fi
+    if [ "$NETLOAD" -gt "$SOURCELOAD" ] && [ "$NETLOAD" -gt "$SOURCEPLOAD" ] && [ "$NETLOAD" -gt "$TARGETLOAD" ]; then
+      BOTTLENECK="Network"
+    fi
+    if [ "$TARGETLOAD" -gt "$SOURCELOAD" ] && [ "$TARGETLOAD" -gt "$SOURCEPLOAD" ] && [ "$TARGETLOAD" -gt "$NETLOAD" ]; then
+      BOTTLENECK="Target"
+    fi
+  fi
+
+  ######################################
+  # Step 5: Duration, timestamps
+  ######################################
+  local DUR DURATIONSEC DURATIONMIN DURATIONHOUR DURATION START END STIME ETIME
+  let DUR=ENDTIME-STARTTIME
+  let DURATIONSEC=DUR%60
+  let DURATIONMIN=\(DUR-DURATIONSEC\)/60%60
+  let DURATIONHOUR=\(DUR-DURATIONSEC-\(DURATIONMIN*60\)\)/3600
+  DURATION=$(printf "%d:%02d:%02d\n" $DURATIONHOUR $DURATIONMIN $DURATIONSEC)
+
+  START=$(date -d "@$STARTTIME" +"%A, %d %B %Y %H:%M:%S")
+  END=$(date -d "@$ENDTIME" +"%A, %d.%m.%Y %H:%M:%S")
+  STIME=$(date -d "@$STARTTIME" +"%H:%M:%S")
+  ETIME=$(date -d "@$ENDTIME"   +"%H:%M:%S")
+
+  ######################################
+  # Step 6: State -> success/warning/fail
+  ######################################
+  local SUCCESS ERROR WARNING BGCOLOR STAT
+  SUCCESS=0
+  ERROR=0
+  WARNING=0
+
+  if [ "$STATE" == "6" ]; then
+    SUCCESS=1; BGCOLOR="#00B050"; STAT="Success";
+    if [ $INFOMAIL -eq 1 ]; then
+      SENDM=1
+    fi
+  fi
+  if [ "$STATE" == "7" ]; then
+    ERROR=1; BGCOLOR="#fb9895"; STAT="Failed";
+    if [ $INFOMAIL -ge 1 ]; then
+      SENDM=1
+    fi
+  fi
+  if [ "$STATE" == "9" ]; then
+    WARNING=1; BGCOLOR="#fbcb95"; STAT="Warning";
+    if [ $INFOMAIL -le 2 ]; then
+      SENDM=1
+    fi
+  fi
+
+  ######################################
+  # If we aren't sending mail at all, skip
+  ######################################
+  if [ $SENDM -ne 1 ]; then
+    return
+  fi
+
+  ######################################
+  # Step 7: Build the HTML email
+  ######################################
+  local TEMPFILE
+  TEMPFILE=$(mktemp)
+
+  local HN
+  HN=${HOSTNAME^^}
+
+  # Build a subject that includes the job name
+  local SUBJECT
+  SUBJECT=$(echo "[$STAT] $HN - $START ($THISJOBNAME)" | base64 -w0)
+
+  # Basic mail headers:
+  {
+    echo "From: $EMAILFROM"
+    echo "To: $EMAILTO"
+    echo "Subject: =?UTF-8?B?$SUBJECT?="
+    echo "MIME-Version: 1.0"
+    echo "Content-Type: text/html; charset=utf-8"
+    echo "Content-Transfer-Encoding: 8bit"
+    echo ""
+  } > "$TEMPFILE"
+
+  # Insert the template, do variable substitutions
+  sed -e "s/XXXJOBNAMEXXX/$THISJOBNAME/g" \
+      -e "s/XXXHOSTNAMEXXX/$HN/g" \
+      -e "s/XXXSTATXXX/$STAT/g" \
+      -e "s/XXXBGCOLORXXX/$BGCOLOR/g" \
+      -e "s/XXXBACKUPDATETIMEXXX/$START/g" \
+      -e "s/XXXSUCCESSXXX/$SUCCESS/g" \
+      -e "s/XXXERRORXXX/$ERROR/g" \
+      -e "s/XXXWARNINGXXX/$WARNING/g" \
+      -e "s/XXXSTARTXXX/$STIME/g" \
+      -e "s/XXXENDXXX/$ETIME/g" \
+      -e "s/XXXDATAREADXXX/$READ/g" \
+      -e "s/XXXREADXXX/$READ/g" \
+      -e "s/XXXTRANSFERREDXXX/$TRANSFERRED/g" \
+      -e "s/XXXDURATIONXXX/$DURATION/g" \
+      -e "s/XXXSTATUSXXX/$STAT/g" \
+      -e "s/XXXTOTALSIZEXXX/$PROCESSED/g" \
+      -e "s/XXXBOTTLENECKXXX/$BOTTLENECK/g" \
+      -e "s|XXXDETAILSXXX|$ERRLOG|g" \
+      -e "s/XXXRATEXXX/$SPEED MB\/s/g" \
+      -e "s/XXXBACKUPSIZEXXX/$TRANSFERRED/g" \
+      -e "s/XXXAGENTXXX/$AGENT/g" \
+      -e "s|XXXTARGETXXX|$TARGET|g" \
+      -e "s|XXXFSTXXX|$FST|g" \
+      -e "s|XXXLOGINXXX|$LOGIN|g" \
+      -e "s|XXXDOMAINXXX|$DOMAIN|g" \
+      -e "s|XXXVERSIONXXX|$VERSION|g" \
+      -e "s|XXXAKTVERSIONXXX|$AKTVERSION|g" \
+      -e "s|XXXDISKSIZEXXX|$DEVSIZE|g" \
+      -e "s|XXXDISKUSEDXXX|$DEVUSED|g" \
+      -e "s|XXXDISKAVAILXXX|$DEVAVAIL|g" \
+      -e "s|XXXDISKUSEPXXX|$DEVUSEP|g" \
+      "$HTMLTEMPLATE" >> "$TEMPFILE"
+
+  ######################################
+  # Step 8: Send the email
+  ######################################
+  if [ $USECURL -eq 1 ]; then
+    local CURLPARAMS=""
+    if [ $CURLSTARTTLS -eq 1 ]; then
+      CURLPARAMS="$CURLPARAMS --ssl-reqd"
+    fi
+    if [ $CURLINSECURE -eq 1 ]; then
+      CURLPARAMS="$CURLPARAMS --insecure"
+    fi
+    $CURL -sS \
+      --url "$CURLSMTPSERVER" \
+      --mail-from "$EMAILFROM" \
+      --mail-rcpt "$EMAILTO" \
+      --upload-file "$TEMPFILE" \
+      ${CURLUSERNAME:+-u $CURLUSERNAME:"$CURLPASSWORD"} \
+      $CURLPARAMS
+  else
+    cat "$TEMPFILE" | $SENDMAIL -f "$EMAILFROM" -t
+  fi
+
+  rm -f "$TEMPFILE"
+}
+
+##################################################
+# If not running in --bg, but started from veeamjobman,
+# re-run in background
+##################################################
+if [ "$1" != "--bg" ] && [ "$STARTEDFROM" == "veeamjobman" ]; then
+  nohup "$0" --bg >/dev/null 2>/dev/null &
   exit
 fi
 
-# (Install dependencies logic remains the same)
-...
-
-# Loop over each job name
+##################################################
+# MAIN: Loop over each job in $JOBS
+##################################################
 for oneJobName in "${JOBS[@]}"; do
-    
-    # Trim whitespace, just in case
-    oneJobName="$(echo "$oneJobName" | xargs)"
-
-    # Adjust the session ID fetch. We want the MOST RECENT session for the current job name
-    # so we limit the job_name in the query:
-    VV=$(veeamconfig -v|cut -c2)
-
-    if [ $VV -ge 6 ]; then
-      # get the most recent session ID for the specific job
-      # The 'job_name' in the DB is typically EXACT to what Veeam sees, so watch out for spacing.
-      SESSID=$($VC session list --name "$oneJobName" | grep -v "Total amount" | tail -1 | awk '{print $(NF-7)}')
-    else
-      SESSID=$($VC session list --name "$oneJobName" | grep -v "Total amount" | tail -1 | awk '{print $(NF-5)}')
-    fi
-    SESSID=${SESSID:1:${#SESSID}-2}
-
-    if [ $VV -ge 6 ]; then
-      SESSDATA=$(sqlite3 /var/lib/veeam/veeam_db.sqlite \
-        "SELECT start_time_utc, end_time_utc, state, progress_details, job_id, job_name 
-         FROM JobSessions 
-         WHERE job_name='$oneJobName'
-         ORDER BY start_time_utc DESC
-         LIMIT 1;"
-      )
-    else
-      SESSDATA=$(sqlite3 /var/lib/veeam/veeam_db.sqlite \
-        "SELECT start_time, end_time, state, progress_details, job_id, job_name 
-         FROM JobSessions 
-         WHERE job_name='$oneJobName'
-         ORDER BY start_time DESC
-         LIMIT 1;"
-      )
-    fi
-
-    STARTTIME=$(echo $SESSDATA | awk -F'|' '{print $1}')
-    ENDTIME=$(echo $SESSDATA   | awk -F'|' '{print $2}')
-    STATE=$(echo $SESSDATA    | awk -F'|' '{print $3}')
-    DETAILS=$(echo $SESSDATA  | awk -F'|' '{print $4}')
-    JOBID=$(echo $SESSDATA    | awk -F'|' '{print $5}')
-    JOBNAME=$(echo $SESSDATA  | awk -F'|' '{print $6}')
-
-    # If there's no session data, skip
-    if [ -z "$SESSDATA" ] || [ -z "$JOBID" ]; then
-      logger -t vee-mail "No sessions found for job [$oneJobName], skipping..."
-      continue
-    fi
-
-    # The rest of your logic for building the email content,
-    # collecting stats, building HTML, etc. remains the same.
-    # e.g. parse $DETAILS for PROCESSED, READ, TRANSFERRED, etc.
-    # parse $JOBID for repository info, etc.
-    # Then build the email / send it.
-
-    # ...
-    # ...
-    # create the subject, etc.
-    HN=${HOSTNAME^^}
-    SUBJECT=$(echo "[$STAT] $HN - $START ($JOBNAME)" | base64 -w0)
-    ...
-    # Then send
-
-done  # end for oneJobName in JOBS
+  # Trim whitespace
+  oneJobName="$(echo "$oneJobName" | xargs)"
+  logger -t vee-mail "Processing job: [$oneJobName]"
+  send_job_mail "$oneJobName"
+done
 
 exit 0
 

--- a/vee-mail.sh
+++ b/vee-mail.sh
@@ -23,7 +23,11 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 # Source config (the .config file, e.g. vee-mail.config)
-. "$HDIR/$1"
+if [ ! "$1" ]; then
+ . "$HDIR/vee-mail.config"
+else
+ . "$HDIR/$1"
+fi
 
 # If config sets SLEEP, use that; else default stays 60
 if [ -z "$SLEEP" ]; then

--- a/vee-mail.sh
+++ b/vee-mail.sh
@@ -4,303 +4,104 @@ VERSION=0.5.49
 HDIR=$(dirname "$0")
 DEBUG=0
 INFOMAIL=1
-# INFOMAIL 1=ALWAYS (DEFAULT), 2=WARN, 3=ERROR
 SENDM=0
-sleep 1
-
-if [ ! $SLEEP ]; then
- SLEEP=60
-fi
+SLEEP=60
 
 if [[ $EUID -ne 0 ]]; then
- echo "This script must be run as root" 
- logger -t vee-mail "This script must be run as root"
- exit 1
+  echo "This script must be run as root" 
+  logger -t vee-mail "This script must be run as root"
+  exit 1
 fi
 
-. $HDIR/vee-mail.config
+# Source your config
+. $HDIR/$1
+
+# Make sure the script picks up the multiple job names
+IFS=',' read -ra JOBS <<< "$JOBNAME"
 
 STARTEDFROM=$(ps -p $PPID -hco cmd)
 if [ "$1" == "--bg" ]; then
- if [ "$STARTEDFROM" == "veeamjobman" ]; then
-  logger -t vee-mail "waiting for 30 seconds"
-  sleep $SLEEP
- fi
+  if [ "$STARTEDFROM" == "veeamjobman" ]; then
+    logger -t vee-mail "waiting for ${SLEEP} seconds"
+    sleep $SLEEP
+  fi
 fi
 
 VC=$(which veeamconfig)
-if [ ! "$VC" ]; then
- echo "No Veeam Agent for Linux installed!"
- logger -t vee-mail "No Veeam Agent for Linux installed!"
- exit
+if [ -z "$VC" ]; then
+  echo "No Veeam Agent for Linux installed!"
+  logger -t vee-mail "No Veeam Agent for Linux installed!"
+  exit
 fi
 
-VV=$(veeamconfig -v|cut -c2)
+# (Install dependencies logic remains the same)
+...
 
-YUM=$(which yum)
+# Loop over each job name
+for oneJobName in "${JOBS[@]}"; do
+    
+    # Trim whitespace, just in case
+    oneJobName="$(echo "$oneJobName" | xargs)"
 
-SQLITE=$(which sqlite3)
-if [ "$SQLITE" != "/usr/bin/sqlite3" ] && [ "$SQLITE" != "/bin/sqlite3" ]; then
- if [ "$YUM" ]; then
-  yum install -y sqlite3
- else
-  apt-get install -y sqlite3
- fi
-fi
+    # Adjust the session ID fetch. We want the MOST RECENT session for the current job name
+    # so we limit the job_name in the query:
+    VV=$(veeamconfig -v|cut -c2)
 
-CURL=$(which curl)
-if [ $USECURL -eq 1 ] && [ ! "$CURL" ]; then
- if [ "$YUM" ]; then
-  yum install -y curl
- else
-  apt-get install -y curl
- fi
-fi
+    if [ $VV -ge 6 ]; then
+      # get the most recent session ID for the specific job
+      # The 'job_name' in the DB is typically EXACT to what Veeam sees, so watch out for spacing.
+      SESSID=$($VC session list --name "$oneJobName" | grep -v "Total amount" | tail -1 | awk '{print $(NF-7)}')
+    else
+      SESSID=$($VC session list --name "$oneJobName" | grep -v "Total amount" | tail -1 | awk '{print $(NF-5)}')
+    fi
+    SESSID=${SESSID:1:${#SESSID}-2}
 
-SENDMAIL=$(which sendmail)
-if [ $USECURL -ne 1 ] &&[ "$SENDMAIL" != "/usr/sbin/sendmail" ] && [ "$SENDMAIL" != "/bin/sendmail" ]; then
- if [ "$YUM" ]; then
-  yum install -y sendmail
- else
-  apt-get install -y sendmail
- fi
-fi
+    if [ $VV -ge 6 ]; then
+      SESSDATA=$(sqlite3 /var/lib/veeam/veeam_db.sqlite \
+        "SELECT start_time_utc, end_time_utc, state, progress_details, job_id, job_name 
+         FROM JobSessions 
+         WHERE job_name='$oneJobName'
+         ORDER BY start_time_utc DESC
+         LIMIT 1;"
+      )
+    else
+      SESSDATA=$(sqlite3 /var/lib/veeam/veeam_db.sqlite \
+        "SELECT start_time, end_time, state, progress_details, job_id, job_name 
+         FROM JobSessions 
+         WHERE job_name='$oneJobName'
+         ORDER BY start_time DESC
+         LIMIT 1;"
+      )
+    fi
 
-if [ $SKIPVERSIONCHECK -ne 1 ]; then
- if [ "$CURL" ]; then
-  AKTVERSION=$($CURL -m2 -f -s https://raw.githubusercontent.com/grufocom/vee-mail/master/vee-mail.sh --stderr - | grep "^VERSION=" | awk -F'=' '{print $2}')
-  if [ "$AKTVERSION" ]; then
-   HIGHESTVERSION=$(echo -e "$VERSION\n$AKTVERSION" | sort -rV | head -n1)
-   if [ "$VERSION" != "$HIGHESTVERSION" ]; then
-    logger -t vee-mail "new Vee-Mail version $AKTVERSION available"
-    AKTVERSION="\(new Vee-Mail version $AKTVERSION available\)"
-   else
-    AKTVERSION=""
-   fi
-  fi
- else
-  AKTVERSION="\(you need curl to use the upgrade check, please install\)"
- fi
-else
- VERSION="$VERSION \(upgrade check disabled\)"
-fi
+    STARTTIME=$(echo $SESSDATA | awk -F'|' '{print $1}')
+    ENDTIME=$(echo $SESSDATA   | awk -F'|' '{print $2}')
+    STATE=$(echo $SESSDATA    | awk -F'|' '{print $3}')
+    DETAILS=$(echo $SESSDATA  | awk -F'|' '{print $4}')
+    JOBID=$(echo $SESSDATA    | awk -F'|' '{print $5}')
+    JOBNAME=$(echo $SESSDATA  | awk -F'|' '{print $6}')
 
-AGENT=$($VC -v)
-# get last session id
-if [ $VV -ge 6 ]; then
- SESSID=$($VC session list|grep -v "Total amount"|tail -1|awk '{print $(NF-7)}')
-else
- SESSID=$($VC session list|grep -v "Total amount"|tail -1|awk '{print $(NF-5)}')
-fi
-SESSID=${SESSID:1:${#SESSID}-2}
+    # If there's no session data, skip
+    if [ -z "$SESSDATA" ] || [ -z "$JOBID" ]; then
+      logger -t vee-mail "No sessions found for job [$oneJobName], skipping..."
+      continue
+    fi
 
-# state 1=Running, 6=Success, 7=Failed, 9=Warning
-# get data from sqlite db
-if [ $VV -ge 6 ]; then
- SESSDATA=$(sqlite3 /var/lib/veeam/veeam_db.sqlite  "select start_time_utc, end_time_utc, state, progress_details, job_id, job_name from JobSessions order by start_time_utc DESC limit 1;")
-else
- SESSDATA=$(sqlite3 /var/lib/veeam/veeam_db.sqlite  "select start_time, end_time, state, progress_details, job_id, job_name from JobSessions order by start_time DESC limit 1;")
-fi
+    # The rest of your logic for building the email content,
+    # collecting stats, building HTML, etc. remains the same.
+    # e.g. parse $DETAILS for PROCESSED, READ, TRANSFERRED, etc.
+    # parse $JOBID for repository info, etc.
+    # Then build the email / send it.
 
-STARTTIME=$(echo $SESSDATA|awk -F'|' '{print $1}')
-ENDTIME=$(echo $SESSDATA|awk -F'|' '{print $2}')
-STATE=$(echo $SESSDATA|awk -F'|' '{print $3}')
-DETAILS=$(echo $SESSDATA|awk -F'|' '{print $4}')
-JOBID=$(echo $SESSDATA|awk -F'|' '{print $5}')
-JOBNAME=$(echo $SESSDATA|awk -F'|' '{print $6}')
+    # ...
+    # ...
+    # create the subject, etc.
+    HN=${HOSTNAME^^}
+    SUBJECT=$(echo "[$STAT] $HN - $START ($JOBNAME)" | base64 -w0)
+    ...
+    # Then send
 
-if [ $DEBUG -gt 0 ]; then
- echo -e -n "STARTTIME: $STARTTIME, ENDTIME: $ENDTIME, STATE: $STATE, JOBID: $JOBID, JOBNAME: $JOBNAME\nDETAILS: $DETAILS\n"
- logger -t vee-mail "STARTTIME: $STARTTIME, ENDTIME: $ENDTIME, STATE: $STATE, JOBID: $JOBID, JOBNAME: $JOBNAME\nDETAILS: $DETAILS"
-fi
+done  # end for oneJobName in JOBS
 
-if [ "$JOBID" ]; then
- RAWTARGET=$(sqlite3 /var/lib/veeam/veeam_db.sqlite "SELECT a1.options FROM BackupRepositories AS a1 LEFT JOIN BackupJobs AS a2 ON a1.id=a2.repository_id WHERE a2.id=\"$JOBID\"")
- TARGET=$(echo $RAWTARGET|awk -F'Address="' '{print $2}'|awk -F'"' '{print $1}'|sed -e "s/^\/\///g")
- FST=$(echo $RAWTARGET|awk -F'FsType="' '{print $2}'|awk -F'"' '{print $1}')
- LOGIN=$(echo $RAWTARGET|awk -F'Login="' '{print $2}'|awk -F'"' '{print $1}')
- DOMAIN=$(echo $RAWTARGET|awk -F'Domain="' '{print $2}'|awk -F'"' '{print $1}')
- if [ $DEBUG -gt 0 ]; then
-  echo -e -n "TARGET: $TARGET, FST: $FST, LOGIN: $LOGIN, DOMAIN: $DOMAIN\n"
-  logger -t vee-mail "TARGET: $TARGET, FST: $FST, LOGIN: $LOGIN, DOMAIN: $DOMAIN"
- fi
- if [ ! "$TARGET" ]; then
-  TARGET=$(echo $RAWTARGET|awk -F'DeviceMountPoint="' '{print $2}'|awk -F'"' '{print $1}')
-  AWKTARGET=$(echo $TARGET | sed 's@/@\\/@g')
-  FST=$(mount | awk -vORS=" " "\$3 ~ /^${AWKTARGET}\$/ {print \$5}")
-  FSD=$(mount | awk -vORS=" " "\$3 ~ /^${AWKTARGET}\$/ {print \$1}")
-  # Filesystem      Size  Used Avail Use% Mounted on
-  DEVSIZE=$(df -hP | awk "\$6 ~ /^${AWKTARGET}\$/ {print \$2}" | sed -e "s/,/\./g" -e "s/M/ M/g" -e "s/G/ G/g" -e "s/T/ T/g" -e "s/P/ P/g")
-  DEVUSED=$(df -hP | awk "\$6 ~ /^${AWKTARGET}\$/ {print \$3}" | sed -e "s/,/\./g" -e "s/M/ M/g" -e "s/G/ G/g" -e "s/T/ T/g" -e "s/P/ P/g")
-  DEVAVAIL=$(df -hP | awk "\$6 ~ /^${AWKTARGET}\$/ {print \$4}" | sed -e "s/,/\./g" -e "s/M/ M/g" -e "s/G/ G/g" -e "s/T/ T/g" -e "s/P/ P/g")
-  DEVUSEP=$(df -hP | awk "\$6 ~ /^${AWKTARGET}\$/ {print \$5}" | sed -e "s/,/\./g" -e "s/M/ M/g" -e "s/G/ G/g" -e "s/T/ T/g" -e "s/P/ P/g")
-  LOGIN=""
-  DOMAIN=""
-  LOCALDEV=1
- fi
- if [ "$FST" == "cifs" ] || [ "$FST" == "smb" ] && [ "$LOCALDEV" != "1" ]; then
-  if [ "$SMBUSER" ] && [ "$SMBPWD" ]; then
-   MPOINT=$(mktemp -d)
-   AWKMPOINT=$(echo $MPOINT | sed 's@/@\\/@g')
-   mount -t cifs -o username=$SMBUSER,password=$SMBPWD,domain=$DOMAIN //$TARGET $MPOINT
-   # Filesystem      Size  Used Avail Use% Mounted on
-   DEVSIZE=$(df -hP | awk "\$6 ~ /^${AWKMPOINT}\$/ {print \$2}" | sed -e "s/,/\./g" -e "s/M/ M/g" -e "s/G/ G/g" -e "s/T/ T/g" -e "s/P/ P/g")
-   DEVUSED=$(df -hP | awk "\$6 ~ /^${AWKMPOINT}\$/ {print \$3}" | sed -e "s/,/\./g" -e "s/M/ M/g" -e "s/G/ G/g" -e "s/T/ T/g" -e "s/P/ P/g")
-   DEVAVAIL=$(df -hP | awk "\$6 ~ /^${AWKMPOINT}\$/ {print \$4}" | sed -e "s/,/\./g" -e "s/M/ M/g" -e "s/G/ G/g" -e "s/T/ T/g" -e "s/P/ P/g")
-   DEVUSEP=$(df -hP | awk "\$6 ~ /^${AWKMPOINT}\$/ {print \$5}" | sed -e "s/,/\./g" -e "s/M/ M/g" -e "s/G/ G/g" -e "s/T/ T/g" -e "s/P/ P/g")
-   umount $MPOINT
-   rmdir $MPOINT
-  fi
- fi
- if [ "$FST" == "nfs" ] && [ "$LOCALDEV" != "1" ]; then
-  MPOINT=$(mktemp -d)
-  mount -t nfs $TARGET $MPOINT
-  AWKMPOINT=$(echo $MPOINT | sed 's@/@\\/@g')
-  # Filesystem      Size  Used Avail Use% Mounted on
-  DEVSIZE=$(df -hP | awk "\$6 ~ /^${AWKMPOINT}\$/ {print \$2}" | sed -e "s/,/\./g" -e "s/M/ M/g" -e "s/G/ G/g" -e "s/T/ T/g" -e "s/P/ P/g")
-  DEVUSED=$(df -hP | awk "\$6 ~ /^${AWKMPOINT}\$/ {print \$3}" | sed -e "s/,/\./g" -e "s/M/ M/g" -e "s/G/ G/g" -e "s/T/ T/g" -e "s/P/ P/g")
-  DEVAVAIL=$(df -hP | awk "\$6 ~ /^${AWKMPOINT}\$/ {print \$4}" | sed -e "s/,/\./g" -e "s/M/ M/g" -e "s/G/ G/g" -e "s/T/ T/g" -e "s/P/ P/g")
-  DEVUSEP=$(df -hP | awk "\$6 ~ /^${AWKMPOINT}\$/ {print \$5}" | sed -e "s/,/\./g" -e "s/M/ M/g" -e "s/G/ G/g" -e "s/T/ T/g" -e "s/P/ P/g")
-  umount $MPOINT
-  rmdir $MPOINT
- fi
-fi
+exit 0
 
-if [ ! "$1" == "--bg" ] && [ "$STARTEDFROM" == "veeamjobman" ]; then 
- nohup $0 --bg >/dev/null 2>/dev/null &
- exit
-fi
-
-if [ "$STATE" == "6" ]; then
- SUCCESS=1; BGCOLOR="#00B050"; STAT="Success";
- if [ $INFOMAIL -eq 1 ]; then
-  SENDM=1
- fi
-else
- SUCCESS=0;
-fi
-if [ "$STATE" == "7" ]; then
- ERROR=1; BGCOLOR="#fb9895"; STAT="Failed";
- if [ $INFOMAIL -ge 1 ]; then
-  SENDM=1
- fi
-else
- ERROR=0;
-fi
-if [ "$STATE" == "9" ]; then
- WARNING=1; BGCOLOR="#fbcb95"; STAT="Warning";
- if [ $INFOMAIL -le 2 ]; then
-  SENDM=1
- fi
-else
- WARNING=0;
-fi
-
-PROCESSED=$(echo $DETAILS|awk -F'processed_data_size_bytes="' '{print $2}'|awk -F'"' '{print $1}')
-PROCESSED=$(awk "BEGIN {printf \"%.1f\n\", $PROCESSED/1024/1024/1024}")" GB"
-READ=$(echo $DETAILS|awk -F'read_data_size_bytes="' '{print $2}'|awk -F'"' '{print $1}')
-READ=$(awk "BEGIN {printf \"%.1f\n\", $READ/1024/1024/1024}")" GB"
-TRANSFERRED=$(echo $DETAILS|awk -F'transferred_data_size_bytes="' '{print $2}'|awk -F'"' '{print $1}')
-if [ $DEBUG -gt 0 ]; then
- echo -e -n "PROCESSED: $PROCESSED, READ: $READ, TRANSFERRED: $TRANSFERRED\n"
- logger -t vee-mail "PROCESSED: $PROCESSED, READ: $READ, TRANSFERRED: $TRANSFERRED"
-fi
-if [ $TRANSFERRED -gt 1073741824 ]; then
- TRANSFERRED=$(awk "BEGIN {printf \"%.1f\n\", $TRANSFERRED/1024/1024/1024}")" GB"
-else
- TRANSFERRED=$(awk "BEGIN {printf \"%.0f\n\", $TRANSFERRED/1024/1024}")" MB"
-fi
-SPEED=$(echo $DETAILS|awk -F'processing_speed="' '{print $2}'|awk -F'"' '{print $1}')
-SPEED=$(awk "BEGIN {printf \"%.1f\n\", $SPEED/1024/1024}")
-SOURCELOAD=$(echo $DETAILS|awk -F'source_read_load="' '{print $2}'|awk -F'"' '{print $1}')
-SOURCEPLOAD=$(echo $DETAILS|awk -F'source_processing_load="' '{print $2}'|awk -F'"' '{print $1}')
-NETLOAD=$(echo $DETAILS|awk -F'network_load="' '{print $2}'|awk -F'"' '{print $1}')
-TARGETLOAD=$(echo $DETAILS|awk -F'target_write_load="' '{print $2}'|awk -F'"' '{print $1}')
-if [ $DEBUG -gt 0 ]; then
- echo -e -n "SPEED: $SPEED, SOURCELOAD: $SOURCELOAD, NETLOAD: $NETLOAD, TARGETLOAD: $TARGETLOAD\n"
- logger -t vee-mail "SPEED: $SPEED, SOURCELOAD: $SOURCELOAD, NETLOAD: $NETLOAD, TARGETLOAD: $TARGETLOAD"
-fi
-
-if [ "$SOURCELOAD" -gt "$SOURCEPLOAD" ] && [ "$SOURCELOAD" -gt "$NETLOAD" ] && [ "$SOURCELOAD" -gt "$TARGETLOAD" ]; then
- BOTTLENECK="Source"
-fi
-if [ "$SOURCEPLOAD" -gt "$SOURCELOAD" ] && [ "$SOURCEPLOAD" -gt "$NETLOAD" ] && [ "$SOURCEPLOAD" -gt "$TARGETLOAD" ]; then
- BOTTLENECK="Source CPU"
-fi
-if [ "$NETLOAD" -gt "$SOURCELOAD" ] && [ "$NETLOAD" -gt "$SOURCEPLOAD" ] && [ "$NETLOAD" -gt "$TARGETLOAD" ]; then
- BOTTLENECK="Network"
-fi
-if [ "$TARGETLOAD" -gt "$SOURCELOAD" ] && [ "$TARGETLOAD" -gt "$SOURCEPLOAD" ] && [ "$TARGETLOAD" -gt "$NETLOAD" ]; then
- BOTTLENECK="Target"
-fi
-
-let DUR=ENDTIME-STARTTIME DURATIONSEC=DUR%60 DURATIONMIN=\(DUR-DURATIONSEC\)/60%60 DURATIONHOUR=\(DUR-DURATIONSEC-\(DURATIONMIN*60\)\)/3600
-DURATION=$(printf "%d:%02d:%02d\n" $DURATIONHOUR $DURATIONMIN $DURATIONSEC)
-START=$(date -d "@$STARTTIME" +"%A, %d %B %Y %H:%M:%S")
-END=$(date -d "@$ENDTIME" +"%A, %d.%m.%Y %H:%M:%S")
-STIME=$(date -d "@$STARTTIME" +"%H:%M:%S")
-ETIME=$(date -d "@$ENDTIME" +"%H:%M:%S")
-
-if [ $DEBUG -gt 0 ]; then
- echo -e -n "DURATION: $DURATION, START: $START, END: $END, STIME: $STIME, ETIME: $ETIME\n"
- logger -t vee-mail "DURATION: $DURATION, START: $START, END: $END, STIME: $STIME, ETIME: $ETIME"
-fi
-
-# get session error
-ERRLOG=$($VC session log --id $SESSID|egrep 'error|warn'|sed ':a;N;$!ba;s/\n/<br>/g'|sed -e "s/ /\&nbsp;/g")
-ERRLOG=$(printf "%q" $ERRLOG)
-if [ "$ERRLOG" == "''" ]; then
- ERRLOG=""
-fi
-
-if [ $DEBUG -gt 0 ]; then
- echo -e -n "ERRLOG: $ERRLOG\n"
- logger -t vee-mail "ERRLOG: $ERRLOG"
-fi
-
-# create temp file for mail
-TEMPFILE=$(mktemp)
-
-# uppercase hostname
-HN=${HOSTNAME^^}
-
-# build email
-SUBJECT=$(echo "[$STAT] $HN - $START"|base64 -w0)
-echo -en "From: $EMAILFROM
-To: $EMAILTO
-Subject: =?UTF-8?B?$SUBJECT?=
-MIME-Version: 1.0
-Content-Type: text/html; charset=utf-8
-Content-Transfer-Encoding: 8bit\r
-\r
-" > $TEMPFILE
-
-# debug output
-if [ $DEBUG -gt 0 ]; then
- echo -e -n "HN: $HN\nSTAT: $STAT\nBGCOLOR: $BGCOLOR\nSTART: $START\nSUCCESS: $SUCCESS\nERROR: $ERROR\nWARNING: $WARNING\nSTIME: $STIME\nETIME: $ETIME\nREAD: $READ\nTRANSFERRED: $TRANSFERRED\nDURATION: $DURATION\nPROCESSED: $PROCESSED\nBOTTLENECK: $BOTTLENECK\nERRLOG: $ERRLOG\nSPEED: $SPEED\nTARGET: $TARGET\nFST: $FST\nLOGIN: $LOGIN\nDOMAIN: $DOMAIN\n DEVUSEP: $DEVUSEP\n"
- logger -t vee-mail "HN: $HN; STAT: $STAT; BGCOLOR: $BGCOLOR; START: $START; SUCCESS: $SUCCESS; ERROR: $ERROR; WARNING: $WARNING; STIME: $STIME; ETIME: $ETIME; READ: $READ; TRANSFERRED: $TRANSFERRED; DURATION: $DURATION; PROCESSED: $PROCESSED; BOTTLENECK: $BOTTLENECK; ERRLOG: $ERRLOG; SPEED: $SPEED; TARGET: $TARGET; FST: $FST; LOGIN: $LOGIN; DOMAIN: $DOMAIN;  DEVUSEP: $DEVUSEP"
-fi
-
-sed -e "s/XXXJOBNAMEXXX/$JOBNAME/g" -e "s/XXXHOSTNAMEXXX/$HN/g" -e "s/XXXSTATXXX/$STAT/g" -e "s/XXXBGCOLORXXX/$BGCOLOR/g" -e "s/XXXBACKUPDATETIMEXXX/$START/g" -e "s/XXXSUCCESSXXX/$SUCCESS/g" -e "s/XXXERRORXXX/$ERROR/g" -e "s/XXXWARNINGXXX/$WARNING/g" -e "s/XXXSTARTXXX/$STIME/g" -e "s/XXXENDXXX/$ETIME/g" -e "s/XXXDATAREADXXX/$READ/g" -e "s/XXXREADXXX/$READ/g" -e "s/XXXTRANSFERREDXXX/$TRANSFERRED/g" -e "s/XXXDURATIONXXX/$DURATION/g" -e "s/XXXSTATUSXXX/$STAT/g" -e "s/XXXTOTALSIZEXXX/$PROCESSED/g" -e "s/XXXBOTTLENECKXXX/$BOTTLENECK/g" -e "s|XXXDETAILSXXX|$ERRLOG|g" -e "s/XXXRATEXXX/$SPEED MB\/s/g" -e "s/XXXBACKUPSIZEXXX/$TRANSFERRED/g" -e "s/XXXAGENTXXX/$AGENT/g" -e "s|XXXTARGETXXX|$TARGET|g" -e "s|XXXFSTXXX|$FST|g" -e "s|XXXLOGINXXX|$LOGIN|g" -e "s|XXXDOMAINXXX|$DOMAIN|g" -e "s|XXXVERSIONXXX|$VERSION|g" -e "s|XXXAKTVERSIONXXX|$AKTVERSION|g" -e "s|XXXDISKSIZEXXX|$DEVSIZE|g" -e "s|XXXDISKUSEDXXX|$DEVUSED|g" -e "s|XXXDISKAVAILXXX|$DEVAVAIL|g" -e "s|XXXDISKUSEPXXX|$DEVUSEP|g" $HTMLTEMPLATE >> $TEMPFILE 
-# send email
-if [ $SENDM -eq 1 ]; then
- if [ $USECURL -eq 1 ]; then
-
-  CURLPARAMS=""
-
-  if [ $CURLSTARTTLS -eq 1 ]; then
-   CURLPARAMS=" $CURLPARAMS --ssl-reqd"
-  fi
-
-  if [ $CURLINSECURE -eq 1 ]; then
-   CURLPARAMS=" $CURLPARAMS --insecure"
-  fi
-
-  $CURL -sS --url $CURLSMTPSERVER --mail-from $EMAILFROM --mail-rcpt $EMAILTO --upload-file $TEMPFILE ${CURLUSERNAME:+-u $CURLUSERNAME:"$CURLPASSWORD"} $CURLPARAMS
- else
-  cat $TEMPFILE | $SENDMAIL -f $EMAILFROM -t
- fi
-fi
-rm $TEMPFILE
-
-exit


### PR DESCRIPTION
It should also be noted that there was an adjustment to the sqlite veeam schema layout for our linux veeam agent version `v6.2.0.101`

```
0|id||1||1
1|job_id||0||0
2|job_name|TEXT|0||0
3|type|INTEGER|0||0
4|state|INTEGER|0||0
5|state_changed_utc|DATETIME|0||0
6|log_text||0||0
7|logs_dir|TEXT|0||0
8|progress|INTEGER|0||0
9|progress_details|TEXT|0||0
10|details|TEXT|0||0
11|retried_session_id|TEXT|0||0
12|usn|INTEGER|0|0|0
13|policy_tag|TEXT|0||0
14|bobject_id|TEXT|0||0
15|point_id|TEXT|0||0
16|creation_time_utc|DATETIME|0||0
17|start_time_utc|DATETIME|0||0
18|end_time_utc|DATETIME|0||0
```
